### PR TITLE
Add SPDX license header check to pre-commit

### DIFF
--- a/.license-header.txt
+++ b/.license-header.txt
@@ -1,0 +1,2 @@
+Copyright 2026 The Bureau Authors
+SPDX-License-Identifier: Apache-2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,53 @@
 
 repos:
   # =============================================================================
+  # License Headers
+  # =============================================================================
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.6
+    hooks:
+      # Go files
+      - id: insert-license
+        name: license-go
+        files: \.go$
+        args:
+          - --license-filepath
+          - .license-header.txt
+          - --comment-style
+          - //
+
+      # Python files
+      - id: insert-license
+        name: license-python
+        files: \.py$
+        args:
+          - --license-filepath
+          - .license-header.txt
+          - --comment-style
+          - "#"
+
+      # Shell scripts
+      - id: insert-license
+        name: license-shell
+        files: ^scripts/.*$
+        exclude: \.(md|txt|gitkeep)$
+        args:
+          - --license-filepath
+          - .license-header.txt
+          - --comment-style
+          - "#"
+
+      # Bazel files
+      - id: insert-license
+        name: license-bazel
+        files: (BUILD\.bazel|\.bzl)$
+        args:
+          - --license-filepath
+          - .license-header.txt
+          - --comment-style
+          - "#"
+
+  # =============================================================================
   # General
   # =============================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary

- Add `insert-license` hooks from Lucas-C/pre-commit-hooks to verify and auto-fix SPDX license headers
- Configured for Go files (`*.go`), Python files (`*.py`), shell scripts (`scripts/*`), and Bazel files (`BUILD.bazel`, `*.bzl`)
- Headers auto-inserted with appropriate comment style per language (`//` for Go, `#` for Python/Shell/Bazel)
- Created `.license-header.txt` containing the expected header text

## Test plan

- [x] Run `pre-commit run --all-files` - all existing files pass
- [x] Verify auto-fix by creating a test file without header - header was correctly inserted
- [x] Verify shell scripts are skipped when no scripts exist

## Notes

Uses [Lucas-C/pre-commit-hooks](https://github.com/Lucas-C/pre-commit-hooks) v1.5.6, which is actively maintained and used by Apache projects (Airflow, Sedona, OpenOffice, CloudStack).

Closes #3