### PR TITLE
Add placeholder test to fix CI bazel test step

### DIFF
--- a/internal/core/BUILD.bazel
+++ b/internal/core/BUILD.bazel
@@ -1,11 +1,17 @@
 # Copyright 2026 The Bureau Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "core",
     srcs = ["core.go"],
     importpath = "github.com/benvanik/bureau/internal/core",
     visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "core_test",
+    srcs = ["core_test.go"],
+    embed = [":core"],
 )

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -1,0 +1,13 @@
+// Copyright 2026 The Bureau Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import "testing"
+
+// TestPlaceholder verifies the core package can be built and tested.
+// Replace this with real tests as functionality is added.
+func TestPlaceholder(t *testing.T) {
+	// This test exists to ensure bazel test //... succeeds when no
+	// other tests exist in the repository.
+}


### PR DESCRIPTION
## Summary

- Adds a minimal placeholder test to `internal/core` that ensures `bazel test //...` succeeds
- This fixes the CI failure when no test targets exist (bazel exits with code 4)
- The placeholder test serves as a template for future tests

Fixes #8

## Test plan

- [x] `bazel test //...` passes locally
- [x] Pre-commit checks pass
- [x] CI passes on this PR